### PR TITLE
remove unnecessary fabs() invocations.

### DIFF
--- a/math/SimplexMethodLP.cc
+++ b/math/SimplexMethodLP.cc
@@ -63,12 +63,12 @@ double simplexMethodPD(double c[], int n, double b[], int m, double A[]) {
 
     if (t < T[q][n+m]) { // tight on c -> primal update
       REP(j, m) if (T[j][p] >= EPS) 
-        if (T[j][p]*fabs(T[q][n+m]-t) >= T[q][p]*fabs(T[j][n+m]-t)) q = j;
+        if (T[j][p]*(T[q][n+m]-t) >= T[q][p]*(T[j][n+m]-t)) q = j;
       if (T[q][p] <= EPS) return INF; // primal infeasible
     } else { // tight on b -> dual update
       REP(i, n+m+1) T[q][i] *= -1;
       REP(i, n+m) if (T[q][i] >= EPS) 
-        if (T[q][i]*fabs(T[m][p]-t) >= T[q][p]*fabs(T[m][i]-t)) p = i;
+        if (T[q][i]*(T[m][p]-t) >= T[q][p]*(T[m][i]-t)) p = i;
       if (T[q][p] <= EPS) return -INF; // dual infeasible
     }
     REP(j, m+1) if (j != q) T[j][p] /= T[q][p]; T[q][p] = 1; // pivot(q,p)


### PR DESCRIPTION
It seems those fabs() are unnecessary: fabs(T[q][n+m]-t), fabs(T[j][n+m]-t), fabs(T[m][p]-t), fabs(T[m][i]-t).
By definition t must be smaller than all of T[q][n+m], T[j][n+m], T[m][p] and T[m][i], hence the arguments of the fabs() invocations are always positive.
