### PR TITLE
change sort comparitor

### DIFF
--- a/geometry/segment_arrangement.cc
+++ b/geometry/segment_arrangement.cc
@@ -245,7 +245,7 @@ struct Arrangement : DoublyConnectedEdgeList {
 
       sort(all(inserter), [&](Node *x, Node *y) {
         const Segment &s = segs[x->index], &t = segs[y->index];
-        return sign(cross(s.q - s.p, t.q - t.p)) >= 0;
+        return sign(cross(s.q - s.p, t.q - t.p)) > 0;
       });
       auto addEvent = [&](Node *x, Node *y) {
         if (!x || !y) return;


### PR DESCRIPTION
With the sort comparator as <=, strict weak ordering is not maintained, i.e. (x, y) and (y, x) can both be present in the relation. In some instances, the result is a seg fault. Changing the comparator to < fixes this.